### PR TITLE
feat(persona): add actions and disable powers for Mare unit

### DIFF
--- a/private/thea/mare.p
+++ b/private/thea/mare.p
@@ -1,0 +1,33 @@
+persona set marker d189e492-93ad-3f2c-698d-d37239d5e741 d189e492-93ad-3f2c-698d-d37239d5e741 d189e492-93ad-3f2c-698d-d37239d5e741
+persona set path $rlv/persona/mare
+persona set action {}
+
+persona set action.yes /me stomps once
+persona set action.no /me stomps twice
+persona set action.hi /me curtsies
+persona set action.bye /me curtsies
+persona set action.nicker /me plays nicker.aiff
+persona set action.snort /me plays snort.mp3
+persona set action.whinny /me plays whinny.wav
+persona set action.lol /me plays nicker.wma
+persona set action.fuck /me plays snort.midi
+
+power mind off
+power inventory off
+power flight off
+power touch-self off
+power far-cam off
+power reach off
+power amplifier off
+power location off
+
+policy bolts on
+policy release off
+
+id name Mare Unit th3a
+
+db set input.censored /me whinnies
+
+security ban $self
+
+say $me is ready to work


### PR DESCRIPTION
This commit introduces a new persona for the 'Mare' unit, including a set of actions such as stomping, curtseying, and playing various sound effects. Additionally, it disables several powers for the unit, including mind, inventory, flight, touch-self, far-cam, reach, amplifier, and location. It also enables the 'bolts' policy and disables the 'release' policy. Finally, it sets the unit's name