### PR TITLE
feat: Increase weight increase after stop command

### DIFF
--- a/wc/index.html
+++ b/wc/index.html
@@ -15,7 +15,7 @@
 
             let MAX_DELAY_SECONDS = 30; // Maximum delay in seconds (1 minute)
 
-            const WEIGHT_INCREASE = 10; // Amount to increase start/stop weight after a stop command
+            const WEIGHT_INCREASE = 13; // Amount to increase start/stop weight after a stop command
 
             const commands = {
                 start: ['pre', 'crack', 'post'],


### PR DESCRIPTION
Increase the WEIGHT_INCREASE constant from 10 to 13 to ensure that the weight is increased by a larger amount after a stop command is issued.